### PR TITLE
Allow to specify a cert name

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,5 +20,5 @@
   register: letsencrypt_cert
 
 - name: Generate new certificate if one doesn't exist
-  shell: "certbot certonly --nginx --email {{ letsencrypt_email }} --agree-tos -d {{ domain_name }} {% if letsencrypt_staging %} --staging {% endif %}"
+  shell: "certbot certonly --nginx --cert-name {{ cert_name }} --email {{ letsencrypt_email }} --agree-tos -d {{ domain_name }} {% if letsencrypt_staging %} --staging {% endif %}"
   when: not letsencrypt_cert.stat.exists


### PR DESCRIPTION
`--cert-name`'s value is the one used in /etc/letsencrypt/live/CERTNAME/cert.pem and to indentify the cert throughout certbot commands.

When creating a cert for multiple domains using the `--domain` flag, according to the docs

> The first domain provided will be the subject CN of the certificate, and all domains will be Subject Alternative Names on the certificate. The first domain will also be used in some software user interfaces and as the file paths for the certificate and related material unless otherwise specified or you already have a certificate with the same name. In the case of a name collision it will append a number like 0001 to the file path name.

Using `--cert-name` allows us to define a specific name other than the one certbot infers, which as you see above could be something like `mydomain-0001`. Sometimes you need to know the final path the cert will be in beforehand.