### PR TITLE
Make cert name optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ Role Variables
 ```yaml
 domain_name: www.mydomain.io
 letsencrypt_email: myaccount@letsencrypt.org
+certbot_nginx_cert_name: mycert # optional
 ```
+
+if set, `certbot_nginx_cert_name`'s value will be passed to the certbot's `--cert-name` argument, which is used to identify the certificate in certbot command such as `certbot delete`. You will see a list of certificates identified with this name by running `certbot certificates`. This name will also be used as the file paths for the certificate in `/etc/letsencrypt/live/`.
 
 Example Playbook
 ----------------
@@ -25,6 +28,7 @@ Example Playbook
     - role: coopdevs.certbot-nginx
       domain_name: www.mydomain.io
       letsencrypt_email: myaccount@letsencrypt.org
+      certbot_nginx_cert_name: mycert
 ```
 
 Let's Encrypt Staging Environment

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Check if certificate already exists
   stat:
-    path: "/etc/letsencrypt/live/{{ certbot_nginx_cert_name | default(domain_name) }}/cert.pem"
+    path: "/etc/letsencrypt/live/{{ certbot_nginx_cert_name | default(domain_name, true) }}/cert.pem"
   register: letsencrypt_cert
 
 - name: Generate new certificate if one doesn't exist

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Check if certificate already exists
   stat:
-    path: "/etc/letsencrypt/live/{{ domain_name }}/cert.pem"
+    path: "/etc/letsencrypt/live/{{ certbot_nginx_cert_name | default(domain_name) }}/cert.pem"
   register: letsencrypt_cert
 
 - name: Generate new certificate if one doesn't exist

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,12 +6,12 @@
 
 - name: Install certbot
   package:
-    name: letsencrypt
+    name: certbot=0.26.1-1+ubuntu16.04.1+certbot+2
     state: present
 
 - name: Install certbot-nginx plugin
   package:
-    name: python-certbot-nginx
+    name: python-certbot-nginx=0.25.0-2+ubuntu16.04.1+certbot+1
     state: present
 
 - name: Check if certificate already exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,12 +6,12 @@
 
 - name: Install certbot
   package:
-    name: certbot=0.26.1-1+ubuntu16.04.1+certbot+2
+    name: "certbot=0.26.1-1+ubuntu{{ ansible_distribution_version }}.1+certbot+2"
     state: present
 
 - name: Install certbot-nginx plugin
   package:
-    name: python-certbot-nginx=0.25.0-2+ubuntu16.04.1+certbot+1
+    name: "python-certbot-nginx=0.25.0-2+ubuntu{{ ansible_distribution_version }}.1+certbot+1"
     state: present
 
 - name: Check if certificate already exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,5 +20,5 @@
   register: letsencrypt_cert
 
 - name: Generate new certificate if one doesn't exist
-  shell: "certbot certonly --nginx --cert-name {{ cert_name }} --email {{ letsencrypt_email }} --agree-tos -d {{ domain_name }} {% if letsencrypt_staging %} --staging {% endif %}"
+  shell: "certbot certonly --nginx --email '{{ letsencrypt_email }}' --agree-tos -d '{{ domain_name }}' {% if cert_name %} --cert-name '{{ cert_name }}' {% endif %} {% if letsencrypt_staging %} --staging {% endif %}"
   when: not letsencrypt_cert.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,5 +20,5 @@
   register: letsencrypt_cert
 
 - name: Generate new certificate if one doesn't exist
-  shell: "certbot certonly --nginx --email '{{ letsencrypt_email }}' --agree-tos -d '{{ domain_name }}' {% if cert_name %} --cert-name '{{ cert_name }}' {% endif %} {% if letsencrypt_staging %} --staging {% endif %}"
+  shell: "certbot certonly --nginx --email '{{ letsencrypt_email }}' --agree-tos -d '{{ domain_name }}' {% if certbot_nginx_cert_name %} --cert-name '{{ certbot_nginx_cert_name }}' {% endif %} {% if letsencrypt_staging %} --staging {% endif %}"
   when: not letsencrypt_cert.stat.exists


### PR DESCRIPTION
## Description

This makes the change in https://github.com/coopdevs/certbot_nginx/pull/6 optional. This way people not using `--cert-name` now don't need to change anything.

You will notice I also

* Fixed the cert-existence check to use this new var
* Changed the var name to follow the naming conventions (`certbot_nginx_cert_name`)
* Added documentation in the README.