### PR TITLE
Add Ubuntu 14.04 and 18.04 support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Simple Ansible role to install `certbot` with NGINX plugin on **Ubuntu 16.04**.
 
 This role will:
 1. Add `certbot` PPA repository
-2. Install `letsencrypt` and `python-certbot-certbot-nginx` packages
-3. `letsencrypt` package will add a `renew` cron job and a systemd-timer ([More info](https://certbot.eff.org/#ubuntuxenial-nginx)
+2. Install `certbot` and `python-certbot-nginx` packages
+3. `certbot` package will add a `renew` cron job and a systemd-timer ([More info](https://certbot.eff.org/#ubuntuxenial-nginx)
 4. Generate a Let's Encrypt SSL certificate for the given `domain_name`
 
 Role Variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,9 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
+    - trusty
     - xenial
+    - bionic
 
   galaxy_tags:
     - certbot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,12 +6,12 @@
 
 - name: Install certbot
   package:
-    name: "certbot=0.26.1-1+ubuntu{{ ansible_distribution_version }}.1+certbot+2"
+    name: "certbot=0.28.0-1+ubuntu{{ ansible_distribution_version }}.1+certbot+4"
     state: present
 
 - name: Install certbot-nginx plugin
   package:
-    name: "python-certbot-nginx=0.25.0-2+ubuntu{{ ansible_distribution_version }}.1+certbot+1"
+    name: "python-certbot-nginx=0.28.0-1+ubuntu{{ ansible_distribution_version }}.1+certbot+3"
     state: present
 
 - name: Check if certificate already exists


### PR DESCRIPTION
We need this role for a project where we are using Ubuntu Bionic 18.04.

I also add the support to Ubuntu Trusty that is required in the issue #8.

The three Ubuntu releases use the same package version but with the distribution in the name:

* Certbot:

```
# Ubuntu 14.04
Candidate: 0.28.0-1+ubuntu14.04.1+certbot+4
# Ubuntu 16.04
Candidate: 0.28.0-1+ubuntu16.04.1+certbot+4
# Ubuntu 18.04
Candidate: 0.28.0-1+ubuntu18.04.1+certbot+4
```

* Certbot NGINX plugin: 

```
# Ubuntu 14.04
Candidate: 0.28.0-1+ubuntu14.04.1+certbot+3
# Ubuntu 16.04
Candidate: 0.28.0-1+ubuntu16.04.1+certbot+3
# Ubuntu 18.04
Candidate: 0.28.0-1+ubuntu18.04.1+certbot+3
```
