### PR TITLE
Move certificate creation to its own task

### DIFF
--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -5,6 +5,5 @@
   register: letsencrypt_cert
 
 - name: Generate new certificate if one doesn't exist
-  shell: "certbot certonly --nginx --email '{{ letsencrypt_email }}' --agree-tos -d '{{ domain_name }}' {% if certbot_nginx_cert_name %} --cert-name '{{ certbot_nginx_cert_name }}' {% endif %} {% if letsencrypt_staging %} --staging {% endif %}"
+  shell: "certbot certonly --nginx --email '{{ letsencrypt_email }}' --agree-tos -d '{{ domain_name }}' {% if certbot_nginx_cert_name is defined %} --cert-name '{{ certbot_nginx_cert_name }}' {% endif %} {% if letsencrypt_staging %} --staging {% endif %}"
   when: not letsencrypt_cert.stat.exists
-

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -1,0 +1,10 @@
+---
+- name: Check if certificate already exists
+  stat:
+    path: "/etc/letsencrypt/live/{{ certbot_nginx_cert_name | default(domain_name, true) }}/cert.pem"
+  register: letsencrypt_cert
+
+- name: Generate new certificate if one doesn't exist
+  shell: "certbot certonly --nginx --email '{{ letsencrypt_email }}' --agree-tos -d '{{ domain_name }}' {% if certbot_nginx_cert_name %} --cert-name '{{ certbot_nginx_cert_name }}' {% endif %} {% if letsencrypt_staging %} --staging {% endif %}"
+  when: not letsencrypt_cert.stat.exists
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,11 +14,5 @@
     name: "python-certbot-nginx=0.28.0-1+ubuntu{{ ansible_distribution_version }}.1+certbot+3"
     state: present
 
-- name: Check if certificate already exists
-  stat:
-    path: "/etc/letsencrypt/live/{{ certbot_nginx_cert_name | default(domain_name, true) }}/cert.pem"
-  register: letsencrypt_cert
-
-- name: Generate new certificate if one doesn't exist
-  shell: "certbot certonly --nginx --email '{{ letsencrypt_email }}' --agree-tos -d '{{ domain_name }}' {% if certbot_nginx_cert_name %} --cert-name '{{ certbot_nginx_cert_name }}' {% endif %} {% if letsencrypt_staging %} --staging {% endif %}"
-  when: not letsencrypt_cert.stat.exists
+- import_tasks: certificate.yml
+  when: domain_name is defined


### PR DESCRIPTION
The idea is to be able to import the task to create certificates from other roles.

The current use case is to create multiple certificates.