### PR TITLE
Add CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+---
+language: python
+python:
+  - "2.7"
+  - "3.6"
+services:
+  - docker
+install:
+  - pip install molecule docker
+script:
+  - molecule --version
+  - ansible --version
+  - molecule test


### PR DESCRIPTION
Thanks to @fapdash we now have molecule ansible tests in place: https://github.com/coopdevs/certbot_nginx/pull/15

With this PR we'll add molecule to Travis CI.