### PR TITLE
Allow updating existing certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Create a custom role including the `certbot_nginx` role that generates the certi
     loop_var: domain_name
 ```
 
-> You need to declare the `loop_control` to map the `item` var of the `with_item` loop with the `loop_var` value as `domain_name`. See the [`loop_controll` doc](https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html?highlight=loop_control#loop-control)
+> You need to declare the `loop_control` to map the `item` var of the `with_item` loop with the `loop_var` value as `domain_name`. See the [`loop_control` doc](https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html?highlight=loop_control#loop-control)
 
 Let's Encrypt Staging Environment
 ---------------------------------

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Create a custom role including the `certbot_nginx` role that generates the certi
 
 > You need to declare the `loop_control` to map the `item` var of the `with_item` loop with the `loop_var` value as `domain_name`. See the [`loop_control` doc](https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html?highlight=loop_control#loop-control)
 
+Updating Existing Certificates
+-------------------------------
+
+If the details for your site have changed since the certificate was created, you can update it by defining `certbot_force_update: true` or passing `--extra-vars "certbot_force_update=true"` via the commandline.
+
+
 Let's Encrypt Staging Environment
 ---------------------------------
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: reload nginx
+  service:
+    name: nginx
+    state: reloaded

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -13,3 +13,14 @@
     {% endif %}
     {% if letsencrypt_staging %} --staging {% endif %}"
   when: not letsencrypt_cert.stat.exists
+
+- name: Force generation of a new certificate
+  shell: >
+    "certbot certonly --force-renewal --nginx --email '{{ letsencrypt_email }}'
+    --agree-tos -d '{{ domain_name }}'
+    {% if certbot_nginx_cert_name is defined %}
+    --cert-name '{{ certbot_nginx_cert_name }}'
+    {% endif %}
+    {% if letsencrypt_staging %} --staging {% endif %}"
+  when: letsencrypt_cert.stat.exists and certbot_force_update is defined
+  notify: reload nginx

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -6,21 +6,21 @@
 
 - name: Generate new certificate if one doesn't exist
   shell: >
-    "certbot certonly --nginx --email '{{ letsencrypt_email }}'
+    certbot certonly --nginx --email '{{ letsencrypt_email }}'
     --agree-tos -d '{{ domain_name }}'
     {% if certbot_nginx_cert_name is defined %}
     --cert-name '{{ certbot_nginx_cert_name }}'
     {% endif %}
-    {% if letsencrypt_staging %} --staging {% endif %}"
+    {% if letsencrypt_staging %} --staging {% endif %}
   when: not letsencrypt_cert.stat.exists
 
 - name: Force generation of a new certificate
   shell: >
-    "certbot certonly --force-renewal --nginx --email '{{ letsencrypt_email }}'
+    certbot certonly --force-renewal --nginx --email '{{ letsencrypt_email }}'
     --agree-tos -d '{{ domain_name }}'
     {% if certbot_nginx_cert_name is defined %}
     --cert-name '{{ certbot_nginx_cert_name }}'
     {% endif %}
-    {% if letsencrypt_staging %} --staging {% endif %}"
+    {% if letsencrypt_staging %} --staging {% endif %}
   when: letsencrypt_cert.stat.exists and certbot_force_update is defined
   notify: reload nginx

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -4,7 +4,7 @@
     path: "/etc/letsencrypt/live/{{ certbot_nginx_cert_name | default(domain_name, true) }}/cert.pem"
   register: letsencrypt_cert
 
-- name: Generate new certificate if one doesn't exist
+- name: "Generate new certificate if one doesn't exist"
   shell: >
     certbot certonly --nginx --email '{{ letsencrypt_email }}'
     --agree-tos -d '{{ domain_name }}'


### PR DESCRIPTION
Hey guys, I just had to update an existing certificate on one of our servers to fix a bug, and realised it wasn't possible with the certbot role. We've had to do this a couple of times, and manually recreate the certificates on servers via the commandline.

I've added a new option here to allow recreating existing certificates when they need to be updated, for example when a new subdomain is added. I also noticed nginx had to be reloaded when changing an existing certificate, so I've added a handler for that.

The new optional task can be run using `--extra-vars "certbot_force_update=true"`.

What do you think?

Relevant docs here: https://certbot.eff.org/docs/using.html#re-creating-and-updating-existing-certificates