### PR TITLE
Certbot removed support for trusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Certbot NGINX [![Build Status](https://travis-ci.org/coopdevs/certbot_nginx.svg?branch=master)](https://travis-ci.org/coopdevs/certbot_nginx)
 =========
 
-Simple Ansible role to install `certbot` with NGINX plugin on **Ubuntu 14.04**, **Ubuntu 16.04** and **Ubuntu 18.04**.
+Simple Ansible role to install `certbot` with NGINX plugin on **Ubuntu 16.04** and **Ubuntu 18.04**.
 
 This role will:
 1. Add `certbot` PPA repository

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
         - bionic
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: instance-trusty
-    image: ubuntu:14.04
   - name: instance-xenial
     image: ubuntu:16.04
   - name: instance-bionic


### PR DESCRIPTION
So do we.
Reference: https://github.com/certbot/certbot/issues/7183
BTW, this deprecation from certbot was breaking tests in trusty. "package certbot not found". Therefore, #23 should now pass the CI tests