### PR TITLE
Specify linters as strings to molecule

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,7 +3,10 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint: yamllint
+lint: |
+  yamllint .
+  ansible-lint
+  flake8
 platforms:
   - name: instance-xenial
     image: ubuntu:16.04
@@ -11,9 +14,7 @@ platforms:
     image: ubuntu:18.04
 provisioner:
   name: ansible
-  lint: ansible-lint
 scenario:
   name: default
 verifier:
   name: testinfra
-  lint: flake8

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,8 +3,7 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: yamllint
 platforms:
   - name: instance-xenial
     image: ubuntu:16.04
@@ -12,11 +11,9 @@ platforms:
     image: ubuntu:18.04
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
+  lint: ansible-lint
 scenario:
   name: default
 verifier:
   name: testinfra
-  lint:
-    name: flake8
+  lint: flake8


### PR DESCRIPTION
This is what Molecule 3 says in https://molecule.readthedocs.io/en/latest/configuration.html#lint.

This (should) fix the build. Currently, the CI badge shows :red_circle: . That's how I noticed.