### PR TITLE
Force the renewal only if is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Create a custom role including the `certbot_nginx` role that generates the certi
 Updating Existing Certificates
 -------------------------------
 
-If the details for your site have changed since the certificate was created, you can update it by defining `certbot_force_update: true` or passing `--extra-vars "certbot_force_update=true"` via the commandline.
+If the details for your site have changed since the certificate was created, you can update the domains list and the role checks the difference between the domains presents in the certificate and the list of domains provided and choose if need to renew the certificate or not. If you want to force the renewal process, you can do it by defining `certbot_force_update: true` or passing `--extra-vars "certbot_force_update=true"` via the commandline.
 
 
 Let's Encrypt Staging Environment

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -14,6 +14,23 @@
     {% if letsencrypt_staging %} --staging {% endif %}
   when: not letsencrypt_cert.stat.exists
 
+# Check if we need or don't need to force the generation of a new certificate
+- name: Extract current domains list from the certificate
+  shell: >
+    sudo certbot certificates | grep 'Domains:' | sed 's/\s*Domains: //'
+  register: old_domains_raw
+  when: certbot_force_update is not defined
+
+- name: Extract domains list
+  set_fact:
+    old_domains: "{{ old_domains_raw['stdout'].split(' ') | sort }}"
+  when: certbot_force_update is not defined
+
+- name: Compare domains with domains in certificate
+  set_fact:
+    certbot_force_update: "{{ old_domains | symmetric_difference(domains) | length | bool }}"
+  when: certbot_force_update is not defined
+
 - name: Force generation of a new certificate
   shell: >
     certbot certonly --force-renewal --nginx --email '{{ letsencrypt_email }}'


### PR DESCRIPTION
Compare the certificate domain list with the domain list provided in the
inventory to check if we need to renew the certificate to add the new
domain or to delete some domain.

If you force the certbot_force_update, Ansible skips these tasks.